### PR TITLE
Remove MonoployTest naming convention

### DIFF
--- a/tdd/src/test/java/com/coderconsole/tdd/generic/MonopolyTest.java
+++ b/tdd/src/test/java/com/coderconsole/tdd/generic/MonopolyTest.java
@@ -20,13 +20,14 @@ class MonopolyTest {
         spy = Mockito.spy(new Monopoly(0)); //
     }
 
-    //Naming Convention:
-
-    //Given when then
-    //when then
-    //given when
-    //returnWhen
-    //doReturnWhen
+    /**
+     * Naming Convention:
+     *   - given when then
+     *   - when then
+     *   - given when
+     *   - returnWhen
+     *   - doReturnWhen
+     */
 
     @Test
     @DisplayName("if the dice has different number return there new position")


### PR DESCRIPTION
Changes
- Renamed the Test to easier understand the naming convention